### PR TITLE
Adding client_id only requests and path query parameter support

### DIFF
--- a/lib/soundclouder.js
+++ b/lib/soundclouder.js
@@ -143,11 +143,11 @@ function call(method, path, access_token, params, callback) {
     }
     callback = callback || function () {};
     params = params || {};
-	if (access_token !== "") {
-	  params.oauth_token = access_token;
-	} else {
-	  params.client_id = client_id;
-	}
+    if (access_token !== "") {
+      params.oauth_token = access_token;
+    } else {
+      params.client_id = client_id;
+    }
     params.format = 'json';
     return request({
       method: method,

--- a/lib/soundclouder.js
+++ b/lib/soundclouder.js
@@ -143,7 +143,11 @@ function call(method, path, access_token, params, callback) {
     }
     callback = callback || function () {};
     params = params || {};
-    params.oauth_token = access_token;
+	if (access_token !== "") {
+	  params.oauth_token = access_token;
+	} else {
+	  params.client_id = client_id;
+	}
     params.format = 'json';
     return request({
       method: method,

--- a/lib/soundclouder.js
+++ b/lib/soundclouder.js
@@ -167,9 +167,10 @@ function call(method, path, access_token, params, callback) {
 
 function request(data, callback) {
   var qsdata = (data.qs) ? qs.stringify(data.qs) : '';
+  var paramChar = data.path.indexOf('?') >= 0 ? '&' : '?';
   var options = {
     hostname: data.uri,
-    path: data.path + '?' + qsdata,
+    path: data.path + paramChar + qsdata,
     method: data.method
   };
 

--- a/test/test.js
+++ b/test/test.js
@@ -72,4 +72,19 @@ vows.describe('soundclouder.js').addBatch({
 		}
     }
   }
+}).addBatch({
+  "When using soundclouder ": {
+    "requests should use client_id": {
+      "when no oath_token is provided": {
+		topic: function() {
+		  sc.get('/tracks/106176078', '', this.callback);
+		},
+		'returns': function(error, data) {
+		  log.event('sc.get() /tracks/103094732');
+		  if (data !== undefined) log.info('data returned');
+		  else log.error(error);
+		}
+	  }
+    }
+  }
 }).export(module);

--- a/test/test.js
+++ b/test/test.js
@@ -87,4 +87,19 @@ vows.describe('soundclouder.js').addBatch({
 	  }
     }
   }
+}).addBatch({
+	"When using soundclouder ": {
+		"requests with query parameters": {
+			"should not error": {
+				topic: function () {
+					sc.get('/tracks?q=rac', '', this.callback);
+				},
+				'returns': function(error, data) {
+					log.event('sc.get() /tracks?q=?rac');
+					if (data !== undefined) log.info('data returned');
+					else log.error(error);
+				}
+			}
+		}
+	}
 }).export(module);


### PR DESCRIPTION
When an empty `oauth_token` is provided the `client_id` will be used for the request. When the requested path contains a `?` the query string will be appended with an `&`.

Example use case:
_As a user, I would like to search Soundcloud without logging in._
This is satisfied by making a request to `/track?q=$search_term&client_id=$client_id`.
