### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 **Table of Contents**  *generated with [DocToc](http://doctoc.herokuapp.com/)*
 
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Soundcloud/functions?utm_source=SoundcloudGithub&utm_medium=button&utm_content=Vender_GitHub)
+
 - [soundclouder.js [![Build Status](https://api.travis-ci.org/khilnani/soundclouder.js.png?branch=master)](https://travis-ci.org/khilnani/soundclouder.js)](#soundclouderjs-!build-statushttpsapitravis-ciorgkhilnanisoundclouderjspngbranch=masterhttpstravis-ciorgkhilnanisoundclouderjs)
 - [SoundCloud APIs Implemented](#soundcloud-apis-implemented)
 - [Usage](#usage)


### PR DESCRIPTION
Hey there. I added a link to the README for a tool where you can test out the Soundcloud API calls in your browser. It's pretty cool because you can export the code snippet into multiple languages as well. I thought it would be useful because I've seen it on other SDKs (Telegram, Shopify and LinkedIn). Full disclosure--I do work on the team that built this tool, but honestly, people seem to find it useful for this kind of stuff.